### PR TITLE
Fixed string "pmkduserx" should be ${USER} for easy copy/paste

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -52,19 +52,19 @@ make
 # when you create the pool by the pmempool create, you may need use the command:
 # PMEMOBJ_CONF="sds.at_create=0" pmempool create obj --layout=queue -s 100M /mnt/pmem-fsdax/queue
 #
-pmempool create obj --layout=warmup -s 100M /mnt/pmem-fsdax0/pmdkuserX/warmup
-./warmup /mnt/pmem-fsdax0/pmdkuserX/warmup
+pmempool create obj --layout=warmup -s 100M /mnt/pmem-fsdax0/${USER}/warmup
+./warmup /mnt/pmem-fsdax0/${USER}/warmup
 
 #
 # find_bugs.cpp
 #
 # Program which contains few bugs. Can you find them?
 #
-pmempool create obj --layout=find_bugs -s 100M /mnt/pmem-fsdax0/pmdkuserX/find_bugs
-./find_bugs /mnt/pmem-fsdax0/pmdkuserX/find_bugs
+pmempool create obj --layout=find_bugs -s 100M /mnt/pmem-fsdax0/${USER}/find_bugs
+./find_bugs /mnt/pmem-fsdax0/${USER}/find_bugs
 
 # run find-bugs under pmemcheck
-valgrind --tool=pmemcheck ./find_bugs /mnt/pmem-fsdax0/pmdkuserX/find_bugs
+valgrind --tool=pmemcheck ./find_bugs /mnt/pmem-fsdax0/${USER}/find_bugs
 
 #
 # queue.cpp
@@ -83,9 +83,9 @@ show
 #
 # Simple implementation of a persistent queue.
 #
-pmempool create obj --layout=queue -s 100M /mnt/pmem-fsdax0/pmdkuserX/queue
-pmempool info /mnt/pmem-fsdax0/pmdkuserX/queue
-./queue_pmemobj /mnt/pmem-fsdax0/pmdkuserX/queue
+pmempool create obj --layout=queue -s 100M /mnt/pmem-fsdax0/${USER}/queue
+pmempool info /mnt/pmem-fsdax0/${USER}/queue
+./queue_pmemobj /mnt/pmem-fsdax0/${USER}/queue
 push 1
 push 2
 push 3
@@ -97,9 +97,9 @@ show
 #
 # Hashmap test program.
 #
-pmempool create obj --layout=simplekv -s 100M /mnt/pmem-fsdax0/pmdkuserX/simplekv-simple
-pmempool info /mnt/pmem-fsdax0/pmdkuserX/simplekv-simple
-./simplekv_simple /mnt/pmem-fsdax0/pmdkuserX/simplekv-simple
+pmempool create obj --layout=simplekv -s 100M /mnt/pmem-fsdax0/${USER}/simplekv-simple
+pmempool info /mnt/pmem-fsdax0/${USER}/simplekv-simple
+./simplekv_simple /mnt/pmem-fsdax0/${USER}/simplekv-simple
 
 #
 # simplekv_word_count.cpp
@@ -107,6 +107,6 @@ pmempool info /mnt/pmem-fsdax0/pmdkuserX/simplekv-simple
 # A C++ program which reads words to a simplekv hashtable and uses MapReduce
 # to count words in specified text files.
 #
-pmempool create obj --layout=simplekv -s 100M /mnt/pmem-fsdax0/pmdkuserX/simplekv-words
-pmempool info /mnt/pmem-fsdax0/pmdkuserX/simplekv-words
-./simplekv_word_count /mnt/pmem-fsdax0/pmdkuserX/simplekv-words words1.txt words2.txt
+pmempool create obj --layout=simplekv -s 100M /mnt/pmem-fsdax0/${USER}/simplekv-words
+pmempool info /mnt/pmem-fsdax0/${USER}/simplekv-words
+./simplekv_word_count /mnt/pmem-fsdax0/${USER}/simplekv-words words1.txt words2.txt

--- a/README.txt
+++ b/README.txt
@@ -77,6 +77,7 @@ push 2
 push 3
 pop
 show
+exit
 
 #
 # queue_pmemobj.cpp
@@ -91,6 +92,7 @@ push 2
 push 3
 pop
 show
+exit
 
 #
 # simplekv_simple.cpp


### PR DESCRIPTION
Substituting the fixed string "pmdkuserx" in the README with the shell variable ${USER} allows attendees to copy/paste without having to substitute their real username each time.

Added the 'exit' command to the two queue examples so the programs exit gracefully.